### PR TITLE
Feat: Polars <-> SQL IO 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "azure-mgmt-sql>=3.0.1",
     "azure-core>=1.30.2",
     "azure-storage-file-datalake>=12.16.0",
+    "polars>=1.14.0",
 ]
 readme = "README.md"
 requires-python = ">= 3.10"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -7,6 +7,7 @@
 #   all-features: false
 #   with-sources: false
 #   generate-hashes: false
+#   universal: false
 
 -e file:.
 alabaster==0.7.16
@@ -110,6 +111,8 @@ platformdirs==4.2.2
     # via virtualenv
 pluggy==1.5.0
     # via pytest
+polars==1.14.0
+    # via azure-connectors
 portalocker==2.10.0
     # via msal-extensions
 pre-commit==3.7.1

--- a/requirements.lock
+++ b/requirements.lock
@@ -7,6 +7,7 @@
 #   all-features: false
 #   with-sources: false
 #   generate-hashes: false
+#   universal: false
 
 -e file:.
 annotated-types==0.7.0
@@ -74,6 +75,8 @@ multidict==6.0.5
     # via yarl
 oauthlib==3.2.2
     # via requests-oauthlib
+polars==1.14.0
+    # via azure-connectors
 portalocker==2.10.0
     # via msal-extensions
 pycparser==2.22

--- a/src/azure_connectors/dataframe_io/read.py
+++ b/src/azure_connectors/dataframe_io/read.py
@@ -1,0 +1,27 @@
+from typing import Any, Literal
+from azure_connectors import AzureSqlConnection
+import sqlalchemy
+import polars as pl
+
+
+def read_df(
+    query: str,
+    iter_batches: Literal[False] = False,
+    batch_size: int | None = None,
+    schema_overrides: pl.Schema | None = None,
+    infer_schema_length: int | None = None,
+    execute_options: dict[str, Any] | None = None,
+) -> pl.DataFrame:
+    sql_info = AzureSqlConnection.from_env()
+    engine: sqlalchemy.Engine = sql_info.engine
+
+    return pl.read_database(
+        query=query,
+        connection=engine,
+        #
+        iter_batches=iter_batches,
+        batch_size=batch_size,
+        schema_overrides=schema_overrides,
+        infer_schema_length=infer_schema_length,
+        execute_options=execute_options,
+    )

--- a/src/azure_connectors/dataframe_io/write.py
+++ b/src/azure_connectors/dataframe_io/write.py
@@ -1,0 +1,22 @@
+from typing import Literal
+from azure_connectors import AzureSqlConnection
+import sqlalchemy
+import polars as pl
+
+
+def write_df(
+    df: pl.DataFrame | pl.LazyFrame,
+    table_name: str,
+    if_table_exists: Literal["append", "replace", "fail"],
+) -> None:
+    sql_info = AzureSqlConnection.from_env()
+    engine: sqlalchemy.Engine = sql_info.engine
+
+    if isinstance(df, pl.LazyFrame):
+        df = df.collect()
+    
+    df.write_database(
+        connection=engine,
+        table_name=table_name,
+        if_table_exists=if_table_exists,
+    )


### PR DESCRIPTION
Add convenience wrappers for:
1. Writing a polars dataframe to database.
2. Reading a database query to polars dataframe.

------------
Can try making df IO stuff optional (i.e., add an `pip install / rye add azure-connectors[df_io]` option) but going to assume it's overkill unless you want it.

Also didn't add tests, but did try both methods and they work (it's still possible that some args don't behave as expected).